### PR TITLE
fix: log clarity (Group C)

### DIFF
--- a/src/yt_dont_recommend/browser.py
+++ b/src/yt_dont_recommend/browser.py
@@ -898,8 +898,6 @@ def process_channels(channel_sources: dict[str, str],
                 if path.lower() in seen_paths:
                     continue
                 seen_paths.add(path.lower())
-                if channel_link:
-                    log.debug(f"Feed card channel: {path}")
                 canonical = channel_lookup.get(path.lower())
                 if canonical and canonical in processed_set:
                     continue
@@ -1114,12 +1112,9 @@ def process_channels(channel_sources: dict[str, str],
                     video_title = cached.get("_video_title", "(unknown)")
                     conf = cached.get("confidence", 0.0)
                     _stages_str = "+".join(cached.get("stages", ["title"]))
-                    log.info(
-                        f"CLICKBAIT: {path} — {video_title!r} "
-                        f"(confidence {conf:.2f}, via {_stages_str}) — marking Not interested..."
-                    )
                     if dry_run:
-                        log.info(f"WOULD MARK NOT INTERESTED: {path} — {video_title!r}")
+                        log.info(f"WOULD MARK NOT INTERESTED: {path} — {video_title!r} "
+                                 f"(confidence {conf:.2f}, via {_stages_str})")
                         clickbait_count += 1
                         found_match_this_pass = True
                         _clickbait_evaluated.add(path.lower())

--- a/src/yt_dont_recommend/clickbait.py
+++ b/src/yt_dont_recommend/clickbait.py
@@ -1171,8 +1171,8 @@ def _classify_title_batch(batch: "list[dict]", cfg: dict) -> "list[dict]":
     if parsed is None:
         log.warning(
             "Batch title parse failed (%s, %.1fs, model=%s) — "
-            "raw response (first 500 chars): %r — falling back to individual calls",
-            _n(len(llm_batch), "item"), elapsed, model, raw[:500],
+            "raw response: %r — falling back to individual calls",
+            _n(len(llm_batch), "item"), elapsed, model, raw,
         )
         for orig_i, item in zip(llm_positions, llm_batch):
             results[orig_i] = classify_title(item["video_id"], item["title"], cfg)
@@ -1311,8 +1311,8 @@ def _classify_transcript_batch(batch: "list[dict]", cfg: dict) -> "list[dict]":
     if parsed is None:
         log.warning(
             "Batch transcript parse failed (%d items, %.1fs, model=%s) — "
-            "raw response (first 500 chars): %r — falling back to individual calls",
-            len(pending_indices), elapsed, model, raw[:500],
+            "raw response: %r — falling back to individual calls",
+            len(pending_indices), elapsed, model, raw,
         )
         for i in pending_indices:
             pre_results[i] = classify_transcript(batch[i]["video_id"], batch[i]["title"], cfg)

--- a/src/yt_dont_recommend/clickbait.py
+++ b/src/yt_dont_recommend/clickbait.py
@@ -1164,7 +1164,7 @@ def _classify_title_batch(batch: "list[dict]", cfg: dict) -> "list[dict]":
         return results  # type: ignore[return-value]
 
     elapsed = round(time.monotonic() - t0, 2)
-    log.debug("Batch title: raw response (%d chars): %.500s", len(raw), raw)
+    log.debug("Batch title: raw response (%d chars): %s", len(raw), raw)
 
     parsed = _parse_batch_response(raw, len(llm_batch))
 
@@ -1304,7 +1304,7 @@ def _classify_transcript_batch(batch: "list[dict]", cfg: dict) -> "list[dict]":
         return [pre_results[i] for i in range(len(batch))]
 
     elapsed = round(time.monotonic() - t0, 2)
-    log.debug("Batch transcript: raw response (%d chars): %.500s", len(raw), raw)
+    log.debug("Batch transcript: raw response (%d chars): %s", len(raw), raw)
 
     parsed = _parse_batch_response(raw, len(pending_indices))
 


### PR DESCRIPTION
## Summary

- **#6** — Dry-run clickbait: `CLICKBAIT: … marking Not interested...` + `WOULD MARK NOT INTERESTED:` both fired for every candidate. Collapsed to a single `WOULD MARK NOT INTERESTED` line that includes confidence/stages — no duplicate.
- **#9** — Raw Ollama batch parse failure warnings truncated response at 500 chars, hiding the actual bad output. Truncation removed; full response now logged.
- **#11** — `Feed card channel: {path}` DEBUG line fired for every successfully parsed DOM card (hundreds of lines per run at `--verbose`). Removed; the JSON-cache fallback path still logs when it kicks in.
- **#7** — Docstring references to `ytInitialData` are intentional (they name the actual JS API); user-visible log messages were already updated in Group A. No change needed here.
- **#13** — Already resolved as a side effect of Group A refactor.

## Test plan
- [ ] `pytest` 232 passed
- [ ] `bash scripts/smoke-test.sh` 19/19
- [ ] Live `--dry-run --clickbait` — confirm single `WOULD MARK NOT INTERESTED` line per candidate, no `CLICKBAIT:` prefix line

🤖 Generated with [Claude Code](https://claude.com/claude-code)