### PR TITLE
fix: clickbait batch parse reliability and timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,8 @@ Run `--check-selectors` to see the exact menu item text in your language — the
 
 ## Acknowledgments
 
+This tool was designed and built in collaboration with [Claude Code](https://claude.ai/claude-code), Anthropic's AI coding assistant, using a model of delegated implementation with human technical authority — design decisions, live test analysis, and iteration happened conversationally, with the human retaining final judgement on architecture, quality gates, and release.
+
 The clickbait detection feature was informed by:
 
 - **ThumbnailTruth** — Naveed, Uzmi & Qazi (2025). *ThumbnailTruth: A Multi-Modal LLM Approach for Detecting Misleading YouTube Thumbnails Across Diverse Cultural Settings.* [arXiv:2509.04714](https://arxiv.org/abs/2509.04714). Their multi-modal dataset and finding that frontier models achieve 93%+ accuracy on thumbnail-based clickbait detection shaped the design of the thumbnail classification stage.

--- a/clickbait-config.example.yaml
+++ b/clickbait-config.example.yaml
@@ -24,7 +24,7 @@ video:
                           # 0.75 is the recommended value for llama3.1:8b;
                           # phi3.5 users should use 0.85 to reduce false positives
     ambiguous_low: 0.4    # confidence >= this but < threshold → run next stage
-    timeout: 300          # seconds per batch LLM call (10 titles/call; 90-150s typical on modest hw)
+    timeout: 600          # seconds per Ollama call (batch or individual fallback); increase on slow/busy hw
     prompt: |
       You are a YouTube clickbait detector. Classify the video title below.
 

--- a/src/yt_dont_recommend/clickbait.py
+++ b/src/yt_dont_recommend/clickbait.py
@@ -1042,6 +1042,8 @@ def _parse_batch_response(raw: str, expected: int) -> "list[dict] | None":
     candidate = raw[start:end + 1]
     # Strip trailing commas before } or ] — common LLM output artifact
     candidate = re.sub(r",(\s*[}\]])", r"\1", candidate)
+    # Remove invalid JSON escape \' — single quotes never need escaping in JSON
+    candidate = candidate.replace("\\'", "'")
     try:
         items = json.loads(candidate)
     except json.JSONDecodeError:

--- a/src/yt_dont_recommend/clickbait.py
+++ b/src/yt_dont_recommend/clickbait.py
@@ -750,11 +750,12 @@ def classify_title(video_id: str, title: str, cfg: dict) -> dict:
     title_cfg = cfg["video"]["title"]
     model     = title_cfg["model"]["name"]
     params    = title_cfg["model"].get("params") or {}
+    timeout   = title_cfg.get("timeout", 600)
 
     prompt = _apply_prompt(title_cfg.get("prompt") or _TITLE_PROMPT, title=title)
     t0 = time.monotonic()
     try:
-        raw = _ollama_chat(model, prompt, params=params)
+        raw = _ollama_chat(model, prompt, params=params, timeout=timeout)
     except Exception as exc:  # noqa: BLE001
         log.warning("Title classification failed for %s: %s", video_id, exc)
         return {
@@ -1114,7 +1115,7 @@ def _classify_title_batch(batch: "list[dict]", cfg: dict) -> "list[dict]":
     title_cfg = cfg["video"]["title"]
     model     = title_cfg["model"]["name"]
     params    = title_cfg["model"].get("params") or {}
-    timeout   = title_cfg.get("timeout", 300)
+    timeout   = title_cfg.get("timeout", 600)
 
     # --- Pre-filter: separate trivially-safe titles from LLM-bound ones ---
     results: list["dict | None"] = [None] * len(batch)

--- a/src/yt_dont_recommend/clickbait.py
+++ b/src/yt_dont_recommend/clickbait.py
@@ -1040,6 +1040,8 @@ def _parse_batch_response(raw: str, expected: int) -> "list[dict] | None":
         return None
 
     candidate = raw[start:end + 1]
+    # Strip trailing commas before } or ] — common LLM output artifact
+    candidate = re.sub(r",(\s*[}\]])", r"\1", candidate)
     try:
         items = json.loads(candidate)
     except json.JSONDecodeError:

--- a/src/yt_dont_recommend/clickbait.py
+++ b/src/yt_dont_recommend/clickbait.py
@@ -1042,8 +1042,10 @@ def _parse_batch_response(raw: str, expected: int) -> "list[dict] | None":
     candidate = raw[start:end + 1]
     # Strip trailing commas before } or ] — common LLM output artifact
     candidate = re.sub(r",(\s*[}\]])", r"\1", candidate)
-    # Remove invalid JSON escape \' — single quotes never need escaping in JSON
-    candidate = candidate.replace("\\'", "'")
+    # Remove invalid JSON escape sequences — any \X where X is not a valid
+    # JSON escape character (", \, /, b, f, n, r, t, uXXXX).  Models sometimes
+    # apply regex/shell-style escaping (\', \d, \s, \j …) inside JSON strings.
+    candidate = re.sub(r'\\([^"\\/bfnrtu])', r'\1', candidate)
     try:
         items = json.loads(candidate)
     except json.JSONDecodeError:

--- a/tests/test_clickbait.py
+++ b/tests/test_clickbait.py
@@ -961,6 +961,21 @@ class TestParseBatchResponseTrailingComma:
         assert result[0]["is_clickbait"] is True
         assert result[0]["confidence"] == 0.85
 
+    def test_escaped_single_quote_in_reasoning(self):
+        """Model emits \' inside a double-quoted JSON string (invalid JSON escape).
+
+        Seen in live logs when a title contains an apostrophe and the model
+        over-escapes it: e.g. "G\\'Kar" in the reasoning field.
+        """
+        raw = (
+            '[{"index": 0, "is_clickbait": false, "confidence": 0.10,'
+            ' "reasoning": "character name G\\\'Kar; no sensational wording"}]'
+        )
+        result = _parse_batch_response(raw, 1)
+        assert result is not None
+        assert result[0]["is_clickbait"] is False
+        assert "G'Kar" in result[0]["reasoning"]
+
 
 # _parse_batch_response — single-quote fallback
 # ---------------------------------------------------------------------------

--- a/tests/test_clickbait.py
+++ b/tests/test_clickbait.py
@@ -924,6 +924,44 @@ class TestClampConfidence:
 
 
 # ---------------------------------------------------------------------------
+# _parse_batch_response — trailing comma stripping
+# ---------------------------------------------------------------------------
+
+
+class TestParseBatchResponseTrailingComma:
+    def test_trailing_comma_after_last_item(self):
+        """Trailing comma after last array element — exact pattern seen in live logs."""
+        raw = (
+            '[\n'
+            '  {"index": 0, "is_clickbait": false, "confidence": 0.1, "reasoning": "ok"},\n'
+            '  {"index": 1, "is_clickbait": true, "confidence": 0.9, "reasoning": "bait"},\n'
+            ']'
+        )
+        result = _parse_batch_response(raw, 2)
+        assert result is not None
+        assert result[0]["is_clickbait"] is False
+        assert result[1]["is_clickbait"] is True
+
+    def test_trailing_comma_inside_object(self):
+        """Trailing comma inside an object (after last key-value pair)."""
+        raw = '[{"index": 0, "is_clickbait": false, "confidence": 0.1, "reasoning": "ok",}]'
+        result = _parse_batch_response(raw, 1)
+        assert result is not None
+        assert result[0]["is_clickbait"] is False
+
+    def test_trailing_comma_both_object_and_array(self):
+        """Trailing comma in both the object and the enclosing array."""
+        raw = (
+            '[\n'
+            '  {"index": 0, "is_clickbait": true, "confidence": 0.85, "reasoning": "bait",},\n'
+            ']'
+        )
+        result = _parse_batch_response(raw, 1)
+        assert result is not None
+        assert result[0]["is_clickbait"] is True
+        assert result[0]["confidence"] == 0.85
+
+
 # _parse_batch_response — single-quote fallback
 # ---------------------------------------------------------------------------
 

--- a/tests/test_clickbait.py
+++ b/tests/test_clickbait.py
@@ -961,12 +961,8 @@ class TestParseBatchResponseTrailingComma:
         assert result[0]["is_clickbait"] is True
         assert result[0]["confidence"] == 0.85
 
-    def test_escaped_single_quote_in_reasoning(self):
-        """Model emits \' inside a double-quoted JSON string (invalid JSON escape).
-
-        Seen in live logs when a title contains an apostrophe and the model
-        over-escapes it: e.g. "G\\'Kar" in the reasoning field.
-        """
+    def test_invalid_escape_single_quote(self):
+        """Model emits \\' inside a double-quoted JSON string (seen in live logs)."""
         raw = (
             '[{"index": 0, "is_clickbait": false, "confidence": 0.10,'
             ' "reasoning": "character name G\\\'Kar; no sensational wording"}]'
@@ -975,6 +971,17 @@ class TestParseBatchResponseTrailingComma:
         assert result is not None
         assert result[0]["is_clickbait"] is False
         assert "G'Kar" in result[0]["reasoning"]
+
+    def test_invalid_escape_other_characters(self):
+        """Model emits other invalid \\X escapes (\\d, \\s, \\j …)."""
+        raw = (
+            '[{"index": 0, "is_clickbait": true, "confidence": 0.85,'
+            ' "reasoning": "uses \\dbait pattern and \\shady wording"}]'
+        )
+        result = _parse_batch_response(raw, 1)
+        assert result is not None
+        assert result[0]["is_clickbait"] is True
+        assert "dbait" in result[0]["reasoning"]
 
 
 # _parse_batch_response — single-quote fallback


### PR DESCRIPTION
## Summary
Cherry-picked infrastructure fixes from #9, separated from the prompt/accuracy changes which will land later with the model swap.

- **Strip trailing commas** from batch LLM JSON responses before parsing (common `llama3.1:8b` artifact: `,]` and `,}`)
- **Strip invalid JSON escape sequences** (`\'`, `\d`, `\s`, etc.) — generalized to all `\X` where X is not a valid JSON escape character
- **Increase title classification timeout** from 300s to 600s default, and wire `classify_title` (individual fallback path) to read the timeout from config instead of using the hardcoded 90s default
- **Add Claude Code collaboration note** to README Acknowledgments

## Why separate from #9
PR #9 also contains prompt changes, few-shot examples, and prefilter additions aimed at reducing false positives. Those are model-dependent and will land alongside the planned model swap. These infrastructure fixes are model-independent and should ship now.

## Test plan
- [x] `pytest` passes (251 tests, 5 new)
- [x] Cherry-picks applied cleanly to main (no conflicts)
- [ ] Live `--clickbait --dry-run` confirms no batch parse warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)