### PR TITLE
chore: integrate ruff linting, fix all issues, update docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev
 
+      - name: Lint with ruff
+        run: uv run ruff check src/ tests/
+
       - name: Run tests
         run: uv run pytest tests/ -v
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versions follow [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **Ruff linting**: integrated ruff for code quality enforcement. Added to CI pipeline (runs before tests on every push/PR). All existing issues fixed.
+- Ruff config in `pyproject.toml` with per-file ignores for intentional patterns (late imports, re-exports).
+
+### Fixed
+- Removed unused imports (`VIDEO_SELECTORS`, `MENU_BTN_SELECTORS`, `MENU_ITEM_SELECTOR`, `TARGET_PHRASES`) left over from the selector registry refactor in browser.py.
+- Fixed ambiguous variable names (`l` → `line`) in scheduler.py.
+- Fixed f-strings with no placeholders, unused test variables, unsorted imports.
+
 ## [0.4.1] - 2026-03-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ No browser extension can do this. Extensions filter content client-side on a sin
 - [Uninstall](#uninstall)
 - [Development Setup](#development-setup)
 - [Usage](#usage)
-- [Exclusion List](#exclusion-list)
+- [Exclusion Lists](#exclusion-lists)
 - [Subscription Protection](#subscription-protection)
 - [Auto-Unblock (False Positive Correction)](#auto-unblock-false-positive-correction)
 - [Blocklist Format](#blocklist-format)
@@ -23,11 +23,13 @@ No browser extension can do this. Extensions filter content client-side on a sin
 - [How It Works](#how-it-works)
 - [State & Logs](#state--logs)
 - [Caveats](#caveats)
+- [Automatic Safeguards](#automatic-safeguards)
 - [Running Periodically](#running-periodically)
 - [Notifications](#notifications)
 - [Updates](#updates)
 - [Checking and Updating Selectors](#checking-and-updating-selectors)
 - [Acknowledgments](#acknowledgments)
+- [Changelog](#changelog)
 - [License](#license)
 
 ---
@@ -190,6 +192,14 @@ A browser window opens — sign into your Google account, then close it. Your se
 > - uv tool: `uvx playwright install-deps chromium`
 > - uv (dev): `uv run playwright install-deps chromium`
 > - pipx / pip/venv: `playwright install-deps chromium`
+
+**Running tests and linting:**
+
+```bash
+uv run pytest tests/ -v        # unit tests (251+)
+uv run ruff check src/ tests/  # lint
+bash scripts/smoke-test.sh     # CLI integration smoke test
+```
 
 ## Usage
 
@@ -621,6 +631,10 @@ The clickbait detection feature was informed by:
 - **ThumbnailTruth** — Naveed, Uzmi & Qazi (2025). *ThumbnailTruth: A Multi-Modal LLM Approach for Detecting Misleading YouTube Thumbnails Across Diverse Cultural Settings.* [arXiv:2509.04714](https://arxiv.org/abs/2509.04714). Their multi-modal dataset and finding that frontier models achieve 93%+ accuracy on thumbnail-based clickbait detection shaped the design of the thumbnail classification stage.
 
 - **Visual Description Grounding** — The two-step thumbnail pipeline (describe what you see literally, then classify from that description) follows an established technique for reducing hallucination in vision-language models. By committing to a factual description before applying classification pressure, the model cannot rationalize a predetermined label by confabulating matching visual evidence.
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for a detailed history of all releases.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,13 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/cmeans/yt-dont-recommend"
 "Bug Tracker" = "https://github.com/cmeans/yt-dont-recommend/issues"
-Changelog = "https://github.com/cmeans/yt-dont-recommend/releases"
+Changelog = "https://github.com/cmeans/yt-dont-recommend/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 dev = [
     "pytest",
     "pyyaml",
+    "ruff",
 ]
 clickbait = [
     "ollama",
@@ -34,3 +35,29 @@ yt-dont-recommend = "yt_dont_recommend.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/yt_dont_recommend"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+ignore = [
+    "E501",   # line too long — handled by formatter if we adopt it later
+]
+
+[tool.ruff.lint.per-file-ignores]
+# __init__.py re-exports names for the _pkg() late-import pattern.
+"src/yt_dont_recommend/__init__.py" = ["F401", "E402"]
+# Sub-modules use late imports to avoid circular dependencies.
+"src/yt_dont_recommend/blocklist.py" = ["E402"]
+"src/yt_dont_recommend/browser.py" = ["E402"]
+"src/yt_dont_recommend/clickbait.py" = ["E402"]
+"src/yt_dont_recommend/diagnostics.py" = ["E402"]
+"src/yt_dont_recommend/unblock.py" = ["E402"]
+"src/yt_dont_recommend/scheduler.py" = ["E402"]
+"src/yt_dont_recommend/cli.py" = ["E402"]
+"src/yt_dont_recommend/state.py" = ["E402"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["yt_dont_recommend"]

--- a/src/yt_dont_recommend/__init__.py
+++ b/src/yt_dont_recommend/__init__.py
@@ -54,91 +54,90 @@ import logging
 log = logging.getLogger(__name__)
 
 # --- Re-exports from config ---
-from .config import (
-    BUILTIN_SOURCES,
-    DEFAULT_SOURCES,
-    PROFILE_DIR,
-    STATE_FILE,
-    LOG_FILE,
-    SCHEDULE_FILE,
-    DEFAULT_BLOCKLIST_EXCLUDE_FILE,
-    DEFAULT_CLICKBAIT_EXCLUDE_FILE,
-    _LEGACY_EXCLUDE_FILE,
-    MIN_DELAY,
-    MAX_DELAY,
-    PAGE_LOAD_WAIT,
-    LONG_PAUSE_EVERY,
-    LONG_PAUSE_SECONDS,
-    MIN_CARDS_FOR_SELECTOR_CHECK,
-    SELECTOR_WARN_AFTER,
-    ATTENTION_FILE,
-    __version__,
-    VERSION_CHECK_INTERVAL,
-    STATE_VERSION,
-    VIDEO_SELECTORS,
-    MENU_BTN_SELECTORS,
-    MENU_ITEM_SELECTOR,
-    TARGET_PHRASES,
-    _SELECTOR_DEFAULTS,
-    load_selectors_config,
-    get_selectors,
-    _LAUNCHD_LABEL,
-    _LAUNCHD_PLIST,
-    _CRON_MARKER,
-    setup_logging,
-    load_schedule_config,
-    _n,
-)
-
-# --- Re-exports from state ---
-from .state import (
-    _had_attention,
-    load_state,
-    save_state,
-    _desktop_notify,
-    _ntfy_notify,
-    write_attention,
-    check_attention_flag,
-)
-
 # --- Re-exports from blocklist ---
 from .blocklist import (
-    parse_text_blocklist,
-    parse_json_blocklist,
-    fetch_remote,
-    resolve_source,
     channel_to_url,
     check_removals,
-)
-
-# --- Re-exports from scheduler ---
-from .scheduler import (
-    load_schedule,
-    save_schedule,
-    _compute_daily_plan,
-    heartbeat,
-    _find_installed_binary,
-    _schedule_macos,
-    _schedule_linux,
-    schedule_cmd,
+    fetch_remote,
+    parse_json_blocklist,
+    parse_text_blocklist,
+    resolve_source,
 )
 
 # --- Re-exports from cli ---
 from .cli import (
+    _clickbait_install_cmd,
+    _detect_installer,
+    _first_run_welcome,
     _get_current_version,
     _get_latest_pypi_version,
     _version_tuple,
-    _detect_installer,
     check_for_update,
     do_auto_upgrade,
     do_revert,
-    setup_notify,
-    remove_notify,
-    test_notify,
-    _first_run_welcome,
     do_uninstall,
-    _clickbait_install_cmd,
     main,
+    remove_notify,
+    setup_notify,
+    test_notify,
+)
+from .config import (
+    _CRON_MARKER,
+    _LAUNCHD_LABEL,
+    _LAUNCHD_PLIST,
+    _LEGACY_EXCLUDE_FILE,
+    _SELECTOR_DEFAULTS,
+    ATTENTION_FILE,
+    BUILTIN_SOURCES,
+    DEFAULT_BLOCKLIST_EXCLUDE_FILE,
+    DEFAULT_CLICKBAIT_EXCLUDE_FILE,
+    DEFAULT_SOURCES,
+    LOG_FILE,
+    LONG_PAUSE_EVERY,
+    LONG_PAUSE_SECONDS,
+    MAX_DELAY,
+    MENU_BTN_SELECTORS,
+    MENU_ITEM_SELECTOR,
+    MIN_CARDS_FOR_SELECTOR_CHECK,
+    MIN_DELAY,
+    PAGE_LOAD_WAIT,
+    PROFILE_DIR,
+    SCHEDULE_FILE,
+    SELECTOR_WARN_AFTER,
+    STATE_FILE,
+    STATE_VERSION,
+    TARGET_PHRASES,
+    VERSION_CHECK_INTERVAL,
+    VIDEO_SELECTORS,
+    __version__,
+    _n,
+    get_selectors,
+    load_schedule_config,
+    load_selectors_config,
+    setup_logging,
+)
+
+# --- Re-exports from scheduler ---
+from .scheduler import (
+    _compute_daily_plan,
+    _find_installed_binary,
+    _schedule_linux,
+    _schedule_macos,
+    heartbeat,
+    load_schedule,
+    save_schedule,
+    schedule_cmd,
+)
+
+# --- Re-exports from state ---
+from .state import (
+    _desktop_notify,
+    _had_attention,
+    _ntfy_notify,
+    check_attention_flag,
+    load_state,
+    save_state,
+    write_attention,
 )
 
 # --- Browser automation thin wrappers ---

--- a/src/yt_dont_recommend/blocklist.py
+++ b/src/yt_dont_recommend/blocklist.py
@@ -15,7 +15,7 @@ import sys
 log = logging.getLogger(__name__)
 from pathlib import Path
 from urllib.parse import urlparse
-from urllib.request import urlopen, Request
+from urllib.request import Request, urlopen
 
 from .config import BUILTIN_SOURCES
 from .state import save_state

--- a/src/yt_dont_recommend/browser.py
+++ b/src/yt_dont_recommend/browser.py
@@ -19,26 +19,22 @@ from pathlib import Path
 from typing import Any
 
 from .config import (
-    PROFILE_DIR,
-    PAGE_LOAD_WAIT,
-    MIN_DELAY,
-    MAX_DELAY,
+    ATTENTION_FILE,
+    DEFAULT_SESSION_CAP,
     LONG_PAUSE_EVERY,
     LONG_PAUSE_SECONDS,
+    MAX_DELAY,
     MIN_CARDS_FOR_SELECTOR_CHECK,
+    MIN_DELAY,
+    PAGE_LOAD_WAIT,
+    PROFILE_DIR,
     SELECTOR_WARN_AFTER,
-    ATTENTION_FILE,
-    VIDEO_SELECTORS,
-    MENU_BTN_SELECTORS,
-    MENU_ITEM_SELECTOR,
-    TARGET_PHRASES,
     _n,
-    pick_viewport,
-    DEFAULT_SESSION_CAP,
-    load_timing_config,
     get_selectors,
+    load_timing_config,
+    pick_viewport,
 )
-from .unblock import _perform_browser_unblocks, _pending_attempted_this_run
+from .unblock import _pending_attempted_this_run, _perform_browser_unblocks
 
 log = logging.getLogger(__name__)
 
@@ -754,9 +750,13 @@ def process_channels(channel_sources: dict[str, str],
         _classify_transcript = None
         if clickbait_cfg is not None:
             try:
+                from .clickbait import (
+                    classify_thumbnail as _classify_thumbnail,
+                )
                 from .clickbait import (  # type: ignore[assignment]
                     classify_titles_batch as _classify_titles_batch,
-                    classify_thumbnail as _classify_thumbnail,
+                )
+                from .clickbait import (
                     classify_transcript as _classify_transcript,
                 )
             except ImportError:

--- a/src/yt_dont_recommend/cli.py
+++ b/src/yt_dont_recommend/cli.py
@@ -15,31 +15,31 @@ import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
-from urllib.request import urlopen, Request
+from urllib.request import Request, urlopen
 
+from .blocklist import check_removals, resolve_source
 from .config import (
-    BUILTIN_SOURCES,
-    DEFAULT_SOURCES,
-    STATE_FILE,
-    LOG_FILE,
-    DEFAULT_BLOCKLIST_EXCLUDE_FILE,
-    DEFAULT_CLICKBAIT_EXCLUDE_FILE,
     _LEGACY_EXCLUDE_FILE,
     ATTENTION_FILE,
-    __version__,
+    BUILTIN_SOURCES,
+    DEFAULT_BLOCKLIST_EXCLUDE_FILE,
+    DEFAULT_CLICKBAIT_EXCLUDE_FILE,
+    DEFAULT_SOURCES,
+    LOG_FILE,
+    STATE_FILE,
     VERSION_CHECK_INTERVAL,
-    setup_logging,
+    __version__,
     _n,
+    setup_logging,
 )
+from .scheduler import _find_installed_binary, schedule_cmd
 from .state import (
+    _ntfy_notify,
+    check_attention_flag,
     load_state,
     save_state,
-    _ntfy_notify,
     write_attention,
-    check_attention_flag,
 )
-from .blocklist import resolve_source, check_removals
-from .scheduler import schedule_cmd, _find_installed_binary
 
 log = logging.getLogger(__name__)
 
@@ -227,24 +227,24 @@ def setup_notify() -> None:
     state = load_state()
     if state.get("notify_topic"):
         topic = state["notify_topic"]
-        print(f"\nNotifications already configured.")
+        print("\nNotifications already configured.")
         print(f"Topic : {topic}")
         print(f"URL   : https://ntfy.sh/{topic}")
-        print(f"\nTo reconfigure, run --remove-notify first.")
+        print("\nTo reconfigure, run --remove-notify first.")
         return
 
     topic = f"ydr-{secrets.token_hex(16)}"
     state["notify_topic"] = topic
     save_state(state)
 
-    print(f"\nNotification topic generated.")
-    print(f"\nSubscribe in the ntfy app or browser:")
+    print("\nNotification topic generated.")
+    print("\nSubscribe in the ntfy app or browser:")
     print(f"  https://ntfy.sh/{topic}")
-    print(f"\nSteps:")
-    print(f"  1. Install the ntfy app (https://ntfy.sh) on your phone or desktop.")
-    print(f"  2. Subscribe to the topic above.")
-    print(f"  3. Run: yt-dont-recommend --test-notify")
-    print(f"\nYour topic is private — it is a random string not guessable by others.")
+    print("\nSteps:")
+    print("  1. Install the ntfy app (https://ntfy.sh) on your phone or desktop.")
+    print("  2. Subscribe to the topic above.")
+    print("  3. Run: yt-dont-recommend --test-notify")
+    print("\nYour topic is private — it is a random string not guessable by others.")
 
 
 def remove_notify() -> None:
@@ -624,7 +624,7 @@ def main() -> None:
             for src in info.get("sources", []):
                 per_source[src] = per_source.get(src, 0) + 1
         if per_source:
-            print(f"\nBlocked by source  :")
+            print("\nBlocked by source  :")
             for src, count in sorted(per_source.items(), key=lambda x: -x[1]):
                 size = state.get("source_sizes", {}).get(src)
                 size_str = f"  (list size: {size})" if size is not None else ""
@@ -636,9 +636,9 @@ def main() -> None:
             total_blocked = len(state.get("blocked_by", {}))
             pct = total_blocked / total_on_lists * 100 if total_on_lists else 0
             print(f"\nFeed coverage      : {total_blocked} of ~{total_on_lists} channels blocked ({pct:.1f}%)")
-            print(f"                     (channels appear in coverage only after showing in the home feed)")
+            print("                     (channels appear in coverage only after showing in the home feed)")
         if whb:
-            print(f"\nSubscribed channels in blocklist (skipped, notified once):")
+            print("\nSubscribed channels in blocklist (skipped, notified once):")
             for ch, info in whb.items():
                 print(f"  {ch}  (sources: {info.get('sources', [])}, first seen: {info.get('first_seen', '?')[:10]})")
         print(f"\nState file         : {STATE_FILE}")
@@ -874,7 +874,7 @@ def main() -> None:
     if not channel_sources and not all_unblocks and clickbait_cfg is None:
         log.info("Nothing to do.")
     else:
-        from .browser import open_browser, close_browser, process_channels
+        from .browser import close_browser, open_browser, process_channels
         browser_handle = open_browser(headless=args.headless)
         if browser_handle is None:
             return  # write_attention already called by open_browser

--- a/src/yt_dont_recommend/clickbait.py
+++ b/src/yt_dont_recommend/clickbait.py
@@ -16,7 +16,6 @@ import base64
 import json
 import logging
 import re
-
 import time
 import urllib.request
 from copy import deepcopy
@@ -708,9 +707,9 @@ def _fetch_transcript(video_id: str) -> "tuple[str | None, str]":
     """
     try:
         from youtube_transcript_api import (
-            YouTubeTranscriptApi,
-            TranscriptsDisabled,
             NoTranscriptFound,
+            TranscriptsDisabled,
+            YouTubeTranscriptApi,
         )
     except ImportError:
         return None, "no_api"

--- a/src/yt_dont_recommend/diagnostics.py
+++ b/src/yt_dont_recommend/diagnostics.py
@@ -15,8 +15,8 @@ from urllib.parse import quote
 log = logging.getLogger(__name__)
 
 from .config import (
-    PROFILE_DIR,
     PAGE_LOAD_WAIT,
+    PROFILE_DIR,
     get_selectors,
 )
 
@@ -49,6 +49,7 @@ def check_selectors(test_channel: str = "@YouTube") -> bool:
     Returns True if the target option was found (exit code 0), False otherwise (exit code 1).
     """
     from playwright.sync_api import sync_playwright
+
     from .config import VIDEO_SELECTORS
 
     sels = get_selectors()

--- a/src/yt_dont_recommend/scheduler.py
+++ b/src/yt_dont_recommend/scheduler.py
@@ -53,21 +53,20 @@ Key behaviours
 """
 
 import json
+import logging
 import random
 import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-import logging
-
 from .config import (
-    LOG_FILE,
-    SCHEDULE_FILE,
-    ATTENTION_FILE,
+    _CRON_MARKER,
     _LAUNCHD_LABEL,
     _LAUNCHD_PLIST,
-    _CRON_MARKER,
+    ATTENTION_FILE,
+    LOG_FILE,
+    SCHEDULE_FILE,
 )
 
 log = logging.getLogger(__name__)
@@ -301,7 +300,7 @@ def _schedule_macos(action: str, bin_path: str, schedule: dict) -> None:
         )
         print(f"Installed:  {plist_path}")
         print(f"Status:     {status}")
-        print(f"Heartbeat:  every minute")
+        print("Heartbeat:  every minute")
         if sched:
             print(f"Modes:      {_modes_summary(sched)}")
             print(f"Headless:   {'yes' if sched.get('headless', True) else 'no'}")
@@ -337,7 +336,7 @@ def _schedule_macos(action: str, bin_path: str, schedule: dict) -> None:
         plistlib.dump(plist, f)
     subprocess.run(["launchctl", "load", str(plist_path)], check=True)
     save_schedule(schedule)
-    print(f"Schedule installed. Heartbeat: every minute.")
+    print("Schedule installed. Heartbeat: every minute.")
     print(f"Modes:      {_modes_summary(schedule)}")
     print(f"Plist:      {plist_path}")
     print(f"Logs:       {LOG_FILE}")
@@ -355,16 +354,16 @@ def _schedule_linux(action: str, bin_path: str, schedule: dict) -> None:
     """
     result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
     existing = result.stdout.splitlines() if result.returncode == 0 else []
-    managed  = [l for l in existing if _CRON_MARKER in l]
-    other    = [l for l in existing if _CRON_MARKER not in l]
+    managed  = [line for line in existing if _CRON_MARKER in line]
+    other    = [line for line in existing if _CRON_MARKER not in line]
 
     if action == "status":
         if not managed:
             print("No schedule installed.")
             return
         sched = load_schedule()
-        print(f"Installed:  crontab entry present")
-        print(f"Heartbeat:  every minute")
+        print("Installed:  crontab entry present")
+        print("Heartbeat:  every minute")
         if sched:
             print(f"Modes:      {_modes_summary(sched)}")
             print(f"Headless:   {'yes' if sched.get('headless', True) else 'no'}")
@@ -375,7 +374,7 @@ def _schedule_linux(action: str, bin_path: str, schedule: dict) -> None:
         if not managed:
             print("No schedule to remove.")
             return
-        new_crontab = "\n".join(l for l in other if l.strip())
+        new_crontab = "\n".join(line for line in other if line.strip())
         if new_crontab and not new_crontab.endswith("\n"):
             new_crontab += "\n"
         subprocess.run(["crontab", "-"], input=new_crontab, text=True, check=True)
@@ -389,11 +388,11 @@ def _schedule_linux(action: str, bin_path: str, schedule: dict) -> None:
     cron_line = (
         f"* * * * * {bin_path} --heartbeat >> /dev/null 2>&1  {_CRON_MARKER}"
     )
-    new_lines   = [l for l in other if l.strip()] + [cron_line]
+    new_lines   = [line for line in other if line.strip()] + [cron_line]
     new_crontab = "\n".join(new_lines) + "\n"
     subprocess.run(["crontab", "-"], input=new_crontab, text=True, check=True)
     save_schedule(schedule)
-    print(f"Schedule installed. Heartbeat: every minute.")
+    print("Schedule installed. Heartbeat: every minute.")
     print(f"Modes:      {_modes_summary(schedule)}")
     print(f"Entry:      {cron_line}")
     print(f"Logs:       {LOG_FILE}")

--- a/src/yt_dont_recommend/state.py
+++ b/src/yt_dont_recommend/state.py
@@ -13,7 +13,7 @@ import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 from typing import TypedDict
-from urllib.request import urlopen, Request
+from urllib.request import Request, urlopen
 
 log = logging.getLogger(__name__)
 
@@ -61,10 +61,12 @@ class AppState(TypedDict, total=False):
     clickbait_acted: dict[str, dict]
 
 from .config import (
-    STATE_FILE as _CONFIG_STATE_FILE,
     ATTENTION_FILE,
-    STATE_VERSION,
     CLICKBAIT_ACTED_PRUNE_DAYS,
+    STATE_VERSION,
+)
+from .config import (
+    STATE_FILE as _CONFIG_STATE_FILE,
 )
 
 # Set to True by write_attention() so main() can exit with code 1 when

--- a/tests/test_blocklist.py
+++ b/tests/test_blocklist.py
@@ -7,18 +7,11 @@ as they did in the original test_yt_dont_recommend.py.
 """
 
 import json
-import pytest
-from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 import yt_dont_recommend as ydr
-from yt_dont_recommend.blocklist import (
-    parse_text_blocklist,
-    parse_json_blocklist,
-    channel_to_url,
-    resolve_source,
-    check_removals,
-)
 
 # Canonical channel IDs used in tests (no leading /).
 # When a test needs to exercise the /@ or /channel/ prefix normalization path,
@@ -445,7 +438,6 @@ class TestPerSourceStats:
         assert "grew by 15" in caplog.text
 
     def test_no_growth_message_when_same_size(self, tmp_path, monkeypatch, caplog):
-        import logging
         monkeypatch.setattr(ydr, "STATE_FILE", tmp_path / "processed.json")
         state = ydr.load_state()
         state["source_sizes"]["deslop"] = 100

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -11,17 +11,15 @@ Functions under test are imported directly from yt_dont_recommend, but
 patch targets that live in cli.py must be patched as yt_dont_recommend.cli.X.
 """
 
-import pytest
 from unittest.mock import MagicMock, patch
 
 import yt_dont_recommend as ydr
 import yt_dont_recommend.unblock as unblock_mod
 from yt_dont_recommend.browser import process_channels
 from yt_dont_recommend.unblock import (
-    _perform_browser_unblocks,
     _MAX_DISPLAY_NAME_RETRIES,
+    _perform_browser_unblocks,
 )
-
 
 # ---------------------------------------------------------------------------
 # First-run welcome and --uninstall
@@ -227,7 +225,7 @@ class TestPerformBrowserUnblocks:
         state["pending_unblock"]["@ghost"]["_retry_count"] = _MAX_DISPLAY_NAME_RETRIES - 2
         page = _make_page(display_name_on_page=None)
 
-        result = _perform_browser_unblocks(page, ["@ghost"], state)
+        _perform_browser_unblocks(page, ["@ghost"], state)
 
         assert "@ghost" in state["pending_unblock"]
         assert state["pending_unblock"]["@ghost"]["_retry_count"] == _MAX_DISPLAY_NAME_RETRIES - 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,6 @@ import pytest
 import yt_dont_recommend as ydr
 from yt_dont_recommend.clickbait import _DEFAULT_CONFIG
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_clickbait.py
+++ b/tests/test_clickbait.py
@@ -2,15 +2,14 @@
 
 import json
 from copy import deepcopy
-from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 from yt_dont_recommend.clickbait import (
+    _DEFAULT_CONFIG,
     _clamp_confidence,
     _deep_merge,
-    _DEFAULT_CONFIG,
     _parse_batch_response,
     _prefilter_title,
     classify_thumbnail,
@@ -22,7 +21,6 @@ from yt_dont_recommend.clickbait import (
     extract_json,
     load_config,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -295,7 +293,7 @@ class TestClassifyThumbnail:
             patch("yt_dont_recommend.clickbait._fetch_thumbnail_b64", return_value="imgdata"),
             patch("yt_dont_recommend.clickbait._ollama_chat", side_effect=mock_chat),
         ):
-            result = classify_thumbnail("vid1", "A title", cfg)
+            classify_thumbnail("vid1", "A title", cfg)
 
         assert len(calls) == 1
         assert calls[0]["has_image"] is True

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -10,18 +10,17 @@ Covers:
 """
 
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import yt_dont_recommend as ydr
 from yt_dont_recommend.scheduler import (
     _compute_daily_plan,
+    _schedule_linux,
+    heartbeat,
     load_schedule,
     save_schedule,
-    heartbeat,
-    _schedule_linux,
     schedule_cmd,
 )
-
 
 # ---------------------------------------------------------------------------
 # _compute_daily_plan
@@ -305,7 +304,7 @@ class TestScheduleLinux:
         _schedule_linux("install", "/bin/yt-dont-recommend", schedule)
 
         assert written, "crontab - was never called"
-        cron_lines = [l for l in written[0].splitlines() if "yt-dont-recommend" in l]
+        cron_lines = [line for line in written[0].splitlines() if "yt-dont-recommend" in line]
         assert cron_lines, "no crontab entry written"
         assert cron_lines[0].startswith("* * * * *"), f"Not every-minute: {cron_lines[0]}"
         assert "--heartbeat" in cron_lines[0]

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -3,15 +3,12 @@ Tests for the selector registry: _SELECTOR_DEFAULTS, load_selectors_config,
 get_selectors, and config override merging.
 """
 
-import json
-import pytest
-from pathlib import Path
 from unittest.mock import patch
 
 from yt_dont_recommend.config import (
     _SELECTOR_DEFAULTS,
-    load_selectors_config,
     get_selectors,
+    load_selectors_config,
 )
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -8,13 +8,9 @@ as they did in the original test_yt_dont_recommend.py.
 
 import json
 import logging
-import pytest
-from pathlib import Path
 from unittest.mock import patch
 
 import yt_dont_recommend as ydr
-from yt_dont_recommend.state import load_state, save_state
-
 
 # ---------------------------------------------------------------------------
 # State management (load_state / save_state)
@@ -146,7 +142,7 @@ class TestVersionChecking:
         assert saved["state_version"] == ydr.STATE_VERSION
 
     def test_state_version_warn_on_newer_schema(self, tmp_path, monkeypatch, caplog):
-        import json, logging
+        import json
         state_file = tmp_path / "processed.json"
         monkeypatch.setattr(ydr, "STATE_FILE", state_file)
         # Write a state file with a future schema version
@@ -156,7 +152,7 @@ class TestVersionChecking:
         assert any("newer version" in r.message for r in caplog.records)
 
     def test_state_version_no_warn_on_same_or_older_schema(self, tmp_path, monkeypatch, caplog):
-        import json, logging
+        import json
         state_file = tmp_path / "processed.json"
         monkeypatch.setattr(ydr, "STATE_FILE", state_file)
         state_file.write_text(json.dumps({"state_version": ydr.STATE_VERSION}))


### PR DESCRIPTION
## Summary
- Integrate **ruff** for code quality enforcement across all source and test files
- Fix all 130 lint issues (unused imports, f-strings, ambiguous vars, import sorting)
- Add ruff to CI pipeline (runs before tests on every push/PR)
- Fix README TOC mismatches and add missing sections

## Ruff config
- Rules: `E` (pycodestyle), `F` (pyflakes), `W` (warnings), `I` (isort)
- Per-file ignores for intentional patterns: `E402` on all modules using late imports, `F401`+`E402` on `__init__.py` re-exports
- Target: Python 3.10, line length 120

## Notable fixes
- 4 unused selector constant imports in browser.py (stale after selector registry refactor)
- Ambiguous `l` → `line` in scheduler.py list comprehensions
- 17 f-strings with no placeholders → plain strings
- Unused test variables and imports cleaned up across all test files

## README updates
- Fixed broken TOC link ("Exclusion List" → "Exclusion Lists")
- Added missing "Automatic Safeguards" and "Changelog" to TOC
- Added test/lint/smoke-test commands to Development Setup
- Added Changelog section linking to CHANGELOG.md
- Updated pyproject.toml Changelog URL

## Test plan
- [x] `ruff check src/ tests/` — all checks passed
- [x] `pytest` — 251 tests passing
- [x] CI will run ruff before tests on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)